### PR TITLE
Use xero-python build in serializer.

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from flask import Flask, url_for, render_template, session, redirect, json, send
 from flask_oauthlib.contrib.client import OAuth, OAuth2Application
 from flask_session import Session
 from xero_python.accounting import AccountingApi, ContactPerson, Contact, Contacts
-from xero_python.api_client import ApiClient
+from xero_python.api_client import ApiClient, serialize
 from xero_python.api_client.configuration import Configuration
 from xero_python.api_client.oauth2 import OAuth2Token
 from xero_python.identity import IdentityApi
@@ -102,12 +102,12 @@ def tenants():
 
     available_tenants = []
     for connection in identity_api.get_connections():
-        tenant = connection.to_dict()
+        tenant = serialize(connection)
         if connection.tenant_type == "ORGANISATION":
             organisations = accounting_api.get_organisations(
                 xero_tenant_id=connection.tenant_id
             )
-            tenant["organisations"] = organisations.to_dict()
+            tenant["organisations"] = serialize(organisations)
 
         available_tenants.append(tenant)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ git+https://github.com/SqrtMinusOne/flask-session.git@560d00f1a84a9924d788a4f4e1
 git+https://github.com/ageis/flask-oauthlib.git@c5ea3ace957ceeeeab3cfb6556f32685ff292eab#egg=Flask-OAuthlib
 
 # Use development version of xero-python
-git+ssh://git@github.com/xero-github/xero-python.git@6b73b76556462052a085de19a9eac46768d244d0#egg=xero-python
+git+ssh://git@github.com/xero-github/xero-python.git@e813f397cbd2ef391291111190a8769de6b21515#egg=xero-python

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,8 @@ from datetime import datetime, date
 from decimal import Decimal
 from functools import singledispatch
 
+from xero_python.api_client.serializer import serialize
+
 
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
@@ -22,7 +24,7 @@ def parse_json(data):
 
 
 def serialize_model(model):
-    return jsonify(model.to_dict())
+    return jsonify(serialize(model))
 
 
 def jsonify(data):


### PR DESCRIPTION
* `serialize` is preferred way to get plain python objects structure for given API model tree.