### PR TITLE
Fix: Set flask version to the last one with session_cookie_name (v2.2.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask==2.2.5
 flask-session==0.3.2
 flask-oauthlib==0.9.6
 xero-python==1.5.3


### PR DESCRIPTION
### Problem
When running the application, it throws a 500 error:
```
Traceback (most recent call last):
  File "/home/santi/.virtualenvs/xero-python/lib/python3.10/site-packages/flask/app.py", line 2189, in wsgi_app
    ctx.push()
  File "/home/santi/.virtualenvs/xero-python/lib/python3.10/site-packages/flask/ctx.py", line 377, in push
    self.session = session_interface.open_session(self.app, self.request)
  File "/home/santi/.virtualenvs/xero-python/lib/python3.10/site-packages/flask_session/sessions.py", line 319, in open_session
    sid = request.cookies.get(app.session_cookie_name)
AttributeError: 'Flask' object has no attribute 'session_cookie_name'
```

### Cause
When installing the application the latest version of Flask is installed, but as of version 2.3.0 flask removed the `session_cookie_name` and other properties.
```
The session_cookie_name, send_file_max_age_default, use_x_sendfile,
propagate_exceptions, and templates_auto_reload properties on app are removed.
```
[Flask changelog for version 2.3.0 here](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0).

### Solution
Set the flask version to 2.2.5 in `requirements.txt`
```
flask==2.2.5
```