### PR TITLE
remove pinned versions from requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please use your Demo Company organisation for your testing.
 ## Getting Started
 
 ### Prerequirements
-* python3.5+ installed
+* python3.9+ installed
 * git installed
 * SSH keys setup for your github profile.
 
@@ -20,6 +20,7 @@ Please use your Demo Company organisation for your testing.
 * Open terminal window and navigate to your `xero-python-oauth2-starter` local drive directory 
 * Create new python virtual environment by running `python3 -m venv venv`
 * Activate new virtual environment by running `source venv/bin/activate`
+* Ensure tools are current `pip install --upgrade pip setuptools wheel`
 * Install project dependencies by running `pip install -r requirements.txt`
 
 ## Create a Xero App

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask
-flask-session==0.3.2
-flask-oauthlib==0.9.6
-xero-python==1.5.3
+flask-session
+flask-oauthlib
+xero-python


### PR DESCRIPTION
It doesn't make sense to have pinned dependencies in requirements.txt file as this a demo app.  Pinned versions can result in the problem we have now were dependencies are out of sync.
* removed pinned version from `flask-session` and `flask-oauthlib`
    * if `flask` is left unpinned, then these should be too
* removed pinned version for `xero-python`
    * the pin at 1.5.3 was very old, the package is up to v 7.0.1
    * checked against python 3.9 and above (all versions not EOL) and all work with latest xero-python (7.0.1)

Updates to the README.md file increase likelihood of success following the instructions
* add step to upgrade pip and tools as some earlier versions can't install xero-python (even version 1.5.3)
* changed to specify python 3.9 and higher as anything lower is EOL so really shouldn't include it